### PR TITLE
[SL-56] feat: 검색기능 구현

### DIFF
--- a/src/components/SearchResultArea.jsx
+++ b/src/components/SearchResultArea.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { ReactComponent as NoContentImg } from 'assets/noContents.svg';
+
+import 'styles/SearchResultArea.scss';
 
 const SearchResultArea = props => {
   const mockData = [
@@ -39,18 +42,26 @@ const SearchResultArea = props => {
   // 향후 query 결과 반영
   const searchResultList = mockData.filter(data => data.title.toLowerCase().includes(searchText));
 
+  if (searchResultList.length === 0) {
+    return (
+      <div className={'search-result-root-empty'}>
+        <NoContentImg />
+        <p>There are no results {searchText} including. </p>
+      </div>
+    );
+  }
   return (
     <div className={'search-result-root'}>
       {searchResultList.map(data => (
         <p className={'search-result-item'} key={data.id}>
-          <span className={'search-result-thumbnail'} />
-          <span className={'search-result-title'}> {data.title} </span>
-          <span className={'search-result-owner'}> {data.owner} </span>
-          <span className={'search-result-description'}> {data.description} </span>
+          <img className={'search-result-thumbnail'} src={data.thumbnail_url} />
+          <div className={'search-result-info'}>
+            <div className={'search-result-title'}> {data.title} </div>
+            <div className={'search-result-owner'}> {data.owner} </div>
+            <div className={'search-result-description'}> {data.description} </div>
+          </div>
         </p>
       ))}
-      <br />
-      {searchParams.get('search')}
     </div>
   );
 };

--- a/src/components/SearchResultArea.jsx
+++ b/src/components/SearchResultArea.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const SearchResultArea = props => {
+  const mockData = [
+    {
+      id: '1',
+      thumbnail_url:
+        'https://mblogthumb-phinf.pstatic.net/MjAyMjAxMjVfMjAy/MDAxNjQzMTAyOTk2NjE0.gw_H_jjBM64svaftcnheR6-mHHlmGOyrr6htAuxPETsg.8JJSQNEA5HX2WmrshjZ-VjmJWqhmgE40Qm5csIud9VUg.JPEG.minziminzi128/IMG_7374.JPG?type=w800',
+      title: 'docker.yml 보여준다',
+      owner: 'din',
+      description:
+        '배포 하기 싫엉 하지만 딘만 할수있어 너가 해야해 니모가 찾아 딘 잘갔다와 오늘은 목요일 집에 가고싶어요',
+    },
+    {
+      id: '2',
+      thumbnail_url:
+        'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcScY6NxLeZ7lgvgqu0b4z03S7GXzpoOMdFB41MAQEYQcQ&s',
+      title: 'docker 말고 프론트앤드 하는 귀여운 개발자임요',
+      owner: 'harry',
+      description: '스트리밍 내가 해본다',
+    },
+    {
+      id: '3',
+      thumbnail_url:
+        'https://www.sungkyul.ac.kr/sites/skumiso/atchmnfl/bbs/1384/thumbnail/temp_1637909879501100.jpg',
+      title: '안녕하세요 나는 조용하지 않은 silence',
+      owner: 'silence',
+      description: '오늘도 심심해 다른 팀 염탐하고 와야징 또 돌아다닌다 귀여운 현호',
+    },
+  ];
+
+  const [searchParams] = useSearchParams();
+  const searchText =
+    searchParams.get('search') !== null
+      ? searchParams.get('search').toLowerCase()
+      : searchParams.get('search');
+
+  // 향후 query 결과 반영
+  const searchResultList = mockData.filter(data => data.title.toLowerCase().includes(searchText));
+
+  return (
+    <div className={'search-result-root'}>
+      {searchResultList.map(data => (
+        <p className={'search-result-item'} key={data.id}>
+          <span className={'search-result-thumbnail'} />
+          <span className={'search-result-title'}> {data.title} </span>
+          <span className={'search-result-owner'}> {data.owner} </span>
+          <span className={'search-result-description'}> {data.description} </span>
+        </p>
+      ))}
+      <br />
+      {searchParams.get('search')}
+    </div>
+  );
+};
+
+export default SearchResultArea;

--- a/src/components/common/SearchField.jsx
+++ b/src/components/common/SearchField.jsx
@@ -1,21 +1,30 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import SearchSvg from 'components/common/SearchSvg';
 import 'styles/SearchField.scss';
 
 const SearchField = props => {
   const { isBordered, placeholder, handleOnSubmit } = props;
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const inputRef = useRef();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    searchParams.delete('search');
+    navigate('/', { replace: true });
+  }, []);
 
   const getContainerClassName = useCallback(() => {
     if (isBordered) return 'search-field-container-bordered';
-    else return 'search-field-container-borderless';
+    return 'search-field-container-borderless';
   }, []);
 
   const onSubmit = useCallback(data => {
     if (data.length !== 0) {
       handleOnSubmit(data);
+      setSearchParams({ search: data });
       inputRef.current.value = '';
     }
   }, []);

--- a/src/styles/SearchResultArea.scss
+++ b/src/styles/SearchResultArea.scss
@@ -1,0 +1,53 @@
+.search-result-root {
+  display: flex;
+  flex-direction: column;
+
+  .search-result-item {
+    display: flex;
+    flex-direction: row;
+    width: 726px;
+    height: 154px;
+    margin: 8px 0px 0px 16px;
+
+    .search-result-thumbnail {
+      width: 224px;
+      height: 126px;
+    }
+    .search-result-info {
+      display: flex;
+      flex-direction: column;
+      margin-left: 8px;
+      color: #3f3f3f;
+
+      .search-result-title {
+        margin-top: 8px;
+        font-weight: 700;
+        font-size: 16px;
+      }
+      .search-result-owner {
+        margin-top: 8px;
+        font-weight: 400;
+        font-size: 12px;
+      }
+      .search-result-description {
+        margin-top: 8px;
+        font-weight: 400;
+        font-size: 8px;
+      }
+    }
+  }
+}
+
+.search-result-root-empty {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 200px;
+
+  p {
+    font-weight: 400;
+    font-size: 16px;
+    color: #a9abb8;
+  }
+}


### PR DESCRIPTION
# Review Request

Mentor
- [ ] @dydwkd486 // 조용장
- [ ] @vidigummy // 류동인
- [ ] @hyeonho9877 // 신현호
- [ ] @kims0uce // 김소연

# Jira Link

# Issue
1. searchFiled 컴포넌트에서 입력받은 값을 url 파라미터로 올렸습니다. (?search={word})
 &rarr; 향후 api 명세 나오면 변경될 수 있습니다. 
2. useSearchParams를 사용하여 'search' key의 value를 가져오고, 그 값이 mockData 배열 원소의 title에 포함된 경우, 해당 객체를 searchResultList에 저장하였습니다. 
3. map 메서드를 사용하여 searchResultList에 저장된 결과들을 출력하도록 하였습니다. 